### PR TITLE
Enable running github action on PR created by forked repo

### DIFF
--- a/.github/workflows/lint-backend.yml
+++ b/.github/workflows/lint-backend.yml
@@ -1,6 +1,9 @@
 name: Python Linting with Ruff
 
-on: push
+on:
+  push:
+    branches: ["main"]
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -1,6 +1,9 @@
 name: FastAPI Testing
 
-on: push
+on:
+  push:
+    branches: ["main"]
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
## I'm submitting a ...

- [ ] bug report
- [x] feature request

## What is the current behavior?
Github action does not run on PRs created by the forked repo.

## What is the expected behavior?
Github action runs on PRs created by the forked repo.
