### PR TITLE
Add build flag to docker compose

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -17,7 +17,7 @@ Please visit this page for more details:
 [https://docs.docker.com/compose/compose-application-model/](https://docs.docker.com/compose/compose-application-model/)
 
 ```
-$ docker compose up
+$ docker compose up --build
 ...
 api  | INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
 ```

--- a/backend/README.md
+++ b/backend/README.md
@@ -17,10 +17,12 @@ Please visit this page for more details:
 [https://docs.docker.com/compose/compose-application-model/](https://docs.docker.com/compose/compose-application-model/)
 
 ```
-$ docker compose up --build
+$ docker compose up
 ...
 api  | INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
 ```
+
+If docker configuration is updated, run with <code>--build</code> flag to rebuild the docker image
 
 ## Running tests locally
 


### PR DESCRIPTION
## I'm submitting a ...
- feature request

## What is the current behavior?
Every time pdm.lock gets updated, the old docker image becomes unusable.

## What is the expected behavior?
Docker image should always be up to date.

## What is the motivation / use case for changing the behavior?
I had an issue starting the container after openai module was installed

## Checklist

- [x] tests are present (if necessary)
- [x] no commented out code
- [x] no debbugging code
- [x] errors are handled
- [x] properly typed
