### PR TITLE
max_length_added_to_ChatRequest

### DIFF
--- a/backend/src/backend/app.py
+++ b/backend/src/backend/app.py
@@ -139,8 +139,9 @@ openai.api_key = OPENAI_API_KEY
 
 
 # Pydantic models for request and response
+# adjust the max_length accordingly
 class ChatRequest(BaseModel):
-    message: str = Field(..., min_length=1)
+    message: str = Field(..., min_length=1, max_length=500)
 
 
 class ChatResponse(BaseModel):

--- a/backend/src/backend/tests.py
+++ b/backend/src/backend/tests.py
@@ -53,7 +53,17 @@ def test_chat_endpoint_malformed_request():
 def test_chat_endpoint_empty_message():
     response = client.post("/api/chat", json={"message": ""})
     assert response.status_code == 400
-    # TODO: Add more specific error message
+    assert "String should have at least 1 character" in response.text
+    assert "type" in response.text
+    assert "loc" in response.text
+    assert "msg" in response.text
+
+
+def test_chat_endpoint_message_too_long():
+    long_message = "a" * 501  # Create a message with 501 characters
+    response = client.post("/api/chat", json={"message": long_message})
+    assert response.status_code == 400
+    assert "String should have at most 500 characters" in response.text
     assert "type" in response.text
     assert "loc" in response.text
     assert "msg" in response.text


### PR DESCRIPTION
## What is the current behavior?
Max Length added to the chat request.
Fixes #60

## What is the expected behavior?
The `message` field in the `ChatRequest` model should have a maximum length to ensure that incoming messages are within a reasonable size, preventing excessively long inputs that could lead to processing delays or errors.

## What is the motivation / use case for changing the behavior?
Adding a `max_length` constraint to the `message` field ensures that the input size is controlled
